### PR TITLE
Patching the deep merge in test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more information about the `SmartCity.TestDataGenerator`, please see [https:
 ```elixir
 def deps do
   [
-    {:smart_city_test, "~> 0.2.5"}
+    {:smart_city_test, "~> 0.2.6"}
   ]
 end
 ```

--- a/lib/smart_city/test_data_generator.ex
+++ b/lib/smart_city/test_data_generator.ex
@@ -56,6 +56,14 @@ defmodule SmartCity.TestDataGenerator do
           }
           | Enumerable.t()
         ) :: SmartCity.Dataset
+  def create_dataset(%{} = overrides) when overrides == %{} do
+    {:ok, dataset} =
+      dataset_example()
+      |> (fn map -> apply(SmartCity.Dataset, :new, [map]) end).()
+
+    dataset
+  end
+
   def create_dataset(%{} = overrides) do
     {:ok, dataset} =
       dataset_example()
@@ -98,6 +106,14 @@ defmodule SmartCity.TestDataGenerator do
           }
           | Enumerable.t()
         ) :: SmartCity.Organization
+  def create_organization(%{} = overrides) when overrides == %{} do
+    {:ok, organization} =
+      organization_example()
+      |> (fn map -> apply(SmartCity.Organization, :new, [map]) end).()
+
+    organization
+  end
+
   def create_organization(%{} = overrides) do
     {:ok, organization} =
       organization_example()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCityTest.MixProject do
   def project do
     [
       app: :smart_city_test,
-      version: "0.2.5",
+      version: "0.2.6",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "redix": {:hex, :redix, "0.9.3", "c51d66657018a9b14f3b4496b1ba70ef6a16e8414cd19b34635242ac371beb95", [:mix], [], "hexpm"},
-  "smart_city": {:hex, :smart_city, "2.1.2", "8a6a029bae5f1b5d5160214e298c7856f641c38ba5f90322f6a1831a57bb8bab", [:mix], [], "hexpm"},
+  "smart_city": {:hex, :smart_city, "2.1.3", "f54b15c05990daf52e338ad335c5f473acf456b25d7c882d4ce09d085752b89e", [:mix], [], "hexpm"},
   "smart_city_data": {:hex, :smart_city_data, "2.1.4", "e550b737fb5105fd1bc02c35b9abf2d537b31f543350811884989754e0b9a284", [:mix], [{:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}, {:smart_city, "~> 2.1", [hex: :smart_city, repo: "hexpm", optional: false]}], "hexpm:smartcolumbus_os"},
   "smart_city_registry": {:hex, :smart_city_registry, "2.6.6", "576f77686a1746949a5b024fb312182e0c93474f890e64b3ffacb8d4ebc48ca2", [:mix], [{:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}, {:redix, "~> 0.9.3", [hex: :redix, repo: "hexpm", optional: false]}, {:smart_city, "~> 2.1", [hex: :smart_city, repo: "hexpm", optional: false]}], "hexpm:smartcolumbus_os"},
 }


### PR DESCRIPTION
Need to make tests pass where query params is expected to be empty, i.e. an empty map. Allows test to override the default value supplied by Faker.