### PR TITLE
Add entropy to dataTitle generation and stop using bad generator

### DIFF
--- a/lib/smart_city/test_data_generator.ex
+++ b/lib/smart_city/test_data_generator.ex
@@ -5,8 +5,21 @@ defmodule SmartCity.TestDataGenerator do
 
   alias SmartCity.TestDataGenerator.Payload
 
+  defp generate_title do
+    random = generate_random_characters(5)
+    fancy_color = Faker.Color.fancy_name()
+    color = Faker.Color.En.name()
+
+    "#{fancy_color}_#{color}_#{random}"
+  end
+
+  defp generate_random_characters(size) do
+    alphabet = String.split("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "", trim: true)
+    Enum.reduce(1..size, [], fn _, acc -> [Enum.random(alphabet) | acc] end)
+  end
+
   defp dataset_example do
-    title = "#{Faker.Color.fancy_name()}_#{Faker.Color.Es.name()}"
+    title = generate_title()
     org = "#{Faker.Color.It.name()}_#{Faker.Cat.name()}"
 
     schema = Payload.get_schema(:test)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SmartCityTest.MixProject do
   def project do
     [
       app: :smart_city_test,
-      version: "0.2.6",
+      version: "0.2.7",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
We saw two problems with the generated system names:
  1. On average, we would have a collision for every 189 system names generated
  2. Presto couldn't handle some characters from the Spanish name generator

This PR should solve both. (We should now have `current_possibilities`*26^5 possible names)